### PR TITLE
Revert "Bump svelte from 3.20.1 to 3.49.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-doc-generator",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6727,9 +6727,9 @@
       }
     },
     "svelte": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-      "integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA=="
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.20.1.tgz",
+      "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q=="
     },
     "svelte-routing": {
       "version": "1.4.0",


### PR DESCRIPTION
Reverts MaMrEzO/svelte-doc-generator#1
Why this PR changes package-lock instead of package.json 🤔